### PR TITLE
Add support for stderr

### DIFF
--- a/interpreter/runtime.cc
+++ b/interpreter/runtime.cc
@@ -107,7 +107,11 @@ GV SeashellInterpreter_Impl::_RT_write(const ArgArray &Args) {
   if (fds[fd].extfd == FD_INTERNAL && (fds[fd].intfd == 1  || fds[fd].intfd == 2)) {
     /** Write to stdout, stderr. */
     std::string toWrite(static_cast<const char*>(buffer), size);
-    val::module_property("_RT_stdout_write")(val(toWrite));
+    if (fds[fd].intfd == 1) {
+      val::module_property("_RT_stdout_write")(val(toWrite));
+    } else if (fds[fd].intfd == 2) {
+      val::module_property("_RT_stderr_write")(val(toWrite));
+    }
     result.IntVal = llvm::APInt(32, size);
   } else if(fds[fd].extfd != FD_INTERNAL) {
     /** TODO: Check if buffer is valid (eventually). */

--- a/interpreter/runtime.js
+++ b/interpreter/runtime.js
@@ -88,6 +88,17 @@ Module._RT_stdin_read = function(wanted) {
 Module._RT_stdout_write = console.log;
 
 /**
+ * void _RT_stderr_write(std::string str)
+ *
+ * Writes str out to stderr, similar to _RT_stdout_write.
+ * This function is meant to be overridden by whatever is
+ * using this library.
+ *
+ * By default, just runs console.log
+ */
+Module._RT_stderr_write = console.log;
+
+/**
  * (void) _RT_stdin_fill(std::string buffer)
  *
  * Fills the standard input buffer.


### PR DESCRIPTION
I modified seashell-clang-js so that it can differentiate stdout and stderr. I need this for the offline testing.